### PR TITLE
Add unit tests, Docker, and dev/prod visual distinction

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+.git
+.github
+.env
+dev.db
+*.png
+*.txt
+RadioCalicoLayout.png
+RadioCalico_Style_Guide.txt
+README.md
+CLAUDE.md
+app.py
+index.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# ---- deps stage: install + compile native modules ----
+FROM node:20-alpine AS deps
+RUN apk add --no-cache python3 make g++
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# ---- dev target ----
+FROM node:20-alpine AS dev
+RUN apk add --no-cache python3 make g++
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+ENV DB_PATH=/data/dev.db
+EXPOSE 3000
+CMD ["npm", "run", "dev"]
+
+# ---- prod target ----
+FROM node:20-alpine AS prod
+RUN apk add --no-cache libstdc++
+WORKDIR /app
+COPY package.json package-lock.json ./
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ENV DB_PATH=/data/dev.db
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - db-data:/data
     environment:
       - DB_PATH=/data/dev.db
+      - APP_ENV=dev
 
   app-prod:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+volumes:
+  db-data:
+
+services:
+  app-dev:
+    build:
+      context: .
+      target: dev
+    profiles: [dev]
+    ports:
+      - "3002:3000"
+    volumes:
+      - .:/app
+      - /app/node_modules
+      - db-data:/data
+    environment:
+      - DB_PATH=/data/dev.db
+
+  app-prod:
+    build:
+      context: .
+      target: prod
+    profiles: [prod]
+    ports:
+      - "3000:3000"
+    volumes:
+      - db-data:/data
+    environment:
+      - DB_PATH=/data/dev.db

--- a/public/index.html
+++ b/public/index.html
@@ -257,6 +257,10 @@
     volumeSlider.addEventListener('input', () => { audio.volume = volumeSlider.value; });
 
     fetchMetadata();
+
+    fetch('/api/config').then(r => r.json()).then(cfg => {
+      if (cfg.env === 'dev') document.body.classList.add('dev-mode');
+    }).catch(() => {});
   </script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -9,6 +9,9 @@ body {
   font-family: "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: #231F20;
 }
+body.dev-mode {
+  background: #FFE5C4;
+}
 
 /* ── Header ── */
 .header {

--- a/server.js
+++ b/server.js
@@ -30,6 +30,10 @@ app.get('/api/health', (req, res) => {
   res.json({ status: 'ok' });
 });
 
+app.get('/api/config', (req, res) => {
+  res.json({ env: process.env.APP_ENV || 'prod' });
+});
+
 app.get('/api/ratings', (req, res) => {
   const song = req.query.song;
   if (!song) return res.status(400).json({ error: 'missing song' });

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ const Database = require('better-sqlite3');
 const crypto = require('crypto');
 
 const app = express();
-const db = new Database('dev.db');
+const db = new Database(process.env.DB_PATH || 'dev.db');
 
 app.set('trust proxy', true);
 app.use(express.json());


### PR DESCRIPTION
## Summary
- Add unit testing framework (Jest) for the ratings API with GitHub Actions CI
- Add Docker containerization with separate dev and prod targets
- Add dev/prod visual distinction: dev site gets an orange background (#FFE5C4) via `/api/config` endpoint and `APP_ENV` env var

## Test plan
- [ ] Run `npm test` to verify unit tests pass
- [ ] Run `docker compose --profile dev up` and confirm orange background on localhost:3002
- [ ] Run `docker compose --profile prod up` and confirm mint green background on localhost:3000
- [ ] Verify `/api/config` returns `{ "env": "dev" }` on dev and `{ "env": "prod" }` on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)